### PR TITLE
Updated participle, supported modules, and minor science changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# generated binaries and typical test files
+kerbal-science-tracker
+persistent.sfs

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/mathuin/kerbal-science-tracker
+
+require (
+	github.com/alecthomas/participle v0.2.0
+	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/alecthomas/participle v0.2.0 h1:MBYD61je/vgb5ktXrXth/OdH23fn1lNnT5cZLw3fkh8=
+github.com/alecthomas/participle v0.2.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/lexer.go
+++ b/lexer.go
@@ -7,23 +7,23 @@ import (
 	"github.com/alecthomas/participle/lexer"
 )
 
-var savefileLexer = lexer.Unquote(lexer.Must(lexer.Regexp(
+var savefileLexer = lexer.Must(lexer.Regexp(
 	`(?m)` +
 		`^([\t\f\r ]+)` +
 		`|(?P<Token>[^\n}{=]*[^\n}{= ])` +
 		`|(?P<Brace>[}{])` +
 		`|(?P<Equal>=)` +
 		`|(?P<Newline>\n)`,
-)))
+))
 
 // Load fills a SaveFile with Terms from a byte array.
 func (s *SaveFile) Load(b []byte) {
 	gstring := bytes.NewReader(b)
 
-	var parser *participle.Parser
-	parser = participle.MustBuild(&SaveFile{}, savefileLexer)
+	parser, err := participle.Build(&SaveFile{}, participle.Lexer(savefileLexer))
 
-	err := parser.Parse(gstring, s)
+	check(err)
+	err = parser.Parse(gstring, s)
 	check(err)
 }
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -21,8 +21,11 @@ func TestLexer(t *testing.T) {
 	for _, tt := range lexertests {
 
 		gstring := strings.NewReader(strings.Join(tt.in, "\n"))
-
-		tokens, err := lexer.ConsumeAll(savefileLexer.Lex(gstring))
+		glex, err := savefileLexer.Lex(gstring)
+		if err != nil {
+			t.Error(err)
+		}
+		tokens, err := lexer.ConsumeAll(glex)
 		if err != nil {
 			t.Error(err)
 		}

--- a/main.go
+++ b/main.go
@@ -40,19 +40,26 @@ func main() {
 	var numterms int
 	var totsci float64
 	var capsci float64
+	var ids []string
 
 	for _, term := range scienceTerms {
 		//		repr.Println(term)
-		var st *ScienceTerm
+		var st *ScienceSubject
 		st, err = Fill(term)
 		if err != nil {
 			continue
 		}
 		numterms = numterms + 1
-		totsci = totsci + st.Sci
-		capsci = capsci + st.Cap
+		totsci = totsci + st.Science
+		capsci = capsci + st.ScienceCap
+		if len(ids) < 10 {
+			ids = append(ids, st.ID)
+		}
 	}
 
 	fmt.Printf("%d missions, %0.2f total science, %0.2f capacity science\n", numterms, totsci, capsci)
+	for i, id := range ids {
+		fmt.Printf("%d: %s\n", i, id)
+	}
 
 }

--- a/science.go
+++ b/science.go
@@ -6,26 +6,35 @@ import (
 	"strings"
 )
 
-// ScienceTerm is the object holding the science term data.
-type ScienceTerm struct {
+// ScienceSubject is the object holding the data pertaining to this subject.
+// https://kerbalspaceprogram.com/api/class_science_subject.html
+type ScienceSubject struct {
 	// FIXME: break ID down into:
-	// - what scientific act (evaReport)
+	// - what experiment (evaReport)
 	// - what body (Kerbin)
-	// - what region (Srf for surface)
-	// - what mode (Splashed)
+	// - what situation (SrfSplashed) https://kerbalspaceprogram.com/api/_science_8cs.html
 	// - what biome (Water)
-	ID    string
-	Title string
-	DSC   int
-	SCV   float64
-	SBV   float64
-	Sci   float64
-	Cap   float64
+	// API has this as two calls:
+	// static string ScienceUtil.GetExperimentBodyName(string subjectID)
+	//
+	// static void ScienceUtil.GetExperimentFieldsFromScienceID	(
+	//	string subjectID,
+	//	out string BodyName,
+	//	out string Situation,
+	//	out string Biome
+	// )
+	ID              string
+	Title           string
+	DataScale       int
+	ScientificValue float64
+	SubjectValue    float64
+	Science         float64
+	ScienceCap      float64
 }
 
-// Fill fills the ScienceTerm with data from the Term object.
-func Fill(t *Term) (*ScienceTerm, error) {
-	s := &ScienceTerm{}
+// Fill fills the ScienceSubject with data from the Term object.
+func Fill(t *Term) (*ScienceSubject, error) {
+	s := &ScienceSubject{}
 	if t.Terms == nil {
 		return nil, errors.New("no terms in science term")
 	}
@@ -41,27 +50,27 @@ func Fill(t *Term) (*ScienceTerm, error) {
 		case "title":
 			s.Title = val
 		case "dsc":
-			s.DSC, err = strconv.Atoi(val)
+			s.DataScale, err = strconv.Atoi(val)
 			if err != nil {
 				return nil, err
 			}
 		case "scv":
-			s.SCV, err = strconv.ParseFloat(val, 64)
+			s.ScientificValue, err = strconv.ParseFloat(val, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "sbv":
-			s.SBV, err = strconv.ParseFloat(val, 64)
+			s.SubjectValue, err = strconv.ParseFloat(val, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "sci":
-			s.Sci, err = strconv.ParseFloat(val, 64)
+			s.Science, err = strconv.ParseFloat(val, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "cap":
-			s.Cap, err = strconv.ParseFloat(val, 64)
+			s.ScienceCap, err = strconv.ParseFloat(val, 64)
 			if err != nil {
 				return nil, err
 			}

--- a/science_test.go
+++ b/science_test.go
@@ -11,7 +11,7 @@ import (
 
 var filltests = []struct {
 	in  *Term
-	out *ScienceTerm
+	out *ScienceSubject
 	err error
 }{
 	{
@@ -43,14 +43,21 @@ var filltests = []struct {
 			&Term{Name: "sci", Values: []string{"5.6"}},
 			&Term{Name: "cap", Values: []string{"7.8"}},
 		}},
-		&ScienceTerm{ID: "id", Title: "title", DSC: 1, SCV: 2, SBV: 3.4, Sci: 5.6, Cap: 7.8},
+		&ScienceSubject{
+			ID:              "id",
+			Title:           "title",
+			DataScale:       1,
+			ScientificValue: 2,
+			SubjectValue:    3.4,
+			Science:         5.6,
+			ScienceCap:      7.8},
 		nil,
 	},
 }
 
 func TestFill(t *testing.T) {
 	for _, tt := range filltests {
-		var out *ScienceTerm
+		var out *ScienceSubject
 		var err error
 		out, err = Fill(tt.in)
 		if !reflect.DeepEqual(out, tt.out) {


### PR DESCRIPTION
Too much for a single PR in the normal case. :-(

Looks like ScienceTerm got changed to ScienceSubject, with struct 
changes to match.

Minor changes to main to list the first ten science subjects.

Lexer code was updated to match current participle logic.

Finally, go modules are now supported, and the .gitignore was updated.